### PR TITLE
Add step to install runc

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -10,6 +10,12 @@
   command: update-alternatives --set editor /usr/bin/vim.basic
   become: yes
 
+- name: Install runc
+  apt:
+    name: runc
+    state: present
+  become: yes
+
 - name: Install docker 
   apt:
     name: docker.io


### PR DESCRIPTION
I keep running into docker errors on the raspberry pi. Installing and configuring runc prior to docker might help mitigate the problem.