### PR TITLE
Disable swap permanently as well

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -80,8 +80,12 @@
   command: kubeadm config images pull
   become: yes
 
-- name: Disable swap
+- name: Disable swap for this session
   command: swapoff -a
+  become: yes
+
+- name: Disable swap permanently
+  command: sed -i "/\/swapfile/d" /etc/fstab
   become: yes
 
 - name: Reset kubernetes


### PR DESCRIPTION
# What/Why
I felt it best to permanently disable swap by backing up `/etc/fstab`, and them removing any swap entries from it. The reason I did this is because `kubelet` fails to start when swap is enabled, and my nodes would reboot and start swap back up again.